### PR TITLE
adding a command line flag for setting the computername 

### DIFF
--- a/respounder.go
+++ b/respounder.go
@@ -171,7 +171,7 @@ func getValidIPv4Addr(addrs []net.Addr) net.IP {
 func initFlags() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Respounder version %1.1f\n", Version)
-		fmt.Fprintf(os.Stderr, "Usage: $ respounder [-json] [-debug] [-computername anewcomputername]")
+		fmt.Fprintf(os.Stderr, "Usage: $ respounder [-json] [-debug] [-computername anewcomputername!]")
 		fmt.Fprintf(os.Stderr, "\n\nFlags:\n")
 		flag.PrintDefaults()
 	}

--- a/respounder.go
+++ b/respounder.go
@@ -49,18 +49,19 @@ var (
 		`Creates a debug.log file with a trace of the program`)
 	
 	compPtr = flag.String("computername", "aweirdcomputername",
-		`Overrides the default computer name`)
+		`Overrides the default computer name, requires at least 16 charcter hostname`)
 
 )
 
 func main() {
 	initFlags()
-
-	fmt.Fprintln(os.Stderr, Banner)
+	flag.Parse()
 
 	if *compPtr != "aweirdcomputername" {
-		computerName = *compPtr
+		computerName = string(*compPtr)
 	}
+
+	fmt.Fprintln(os.Stderr, Banner)
 
 	interfaces, _ := net.Interfaces()
 	logger.Println("======== Starting RESPOUNDER ========")


### PR DESCRIPTION
makes the tool slightly more configurable by allowing the computer name it broadcasts to be specified from the command line flags